### PR TITLE
Fix wrong argument order in unit test

### DIFF
--- a/src/test/java/com/techtwist/controllers/ProductControllerTest.java
+++ b/src/test/java/com/techtwist/controllers/ProductControllerTest.java
@@ -54,7 +54,16 @@ class ProductControllerTest {
     }
 
     private Product createTestProduct() {
-        return new Product("1", "Product1", 10.0, "Product Description", "imugeurl", "category", "brand", rowKey, "partitionKey");
+        return new Product(
+                "1",
+                "Product1",
+                10.0,
+                "Product Description",
+                "imugeurl",
+                "category",
+                "brand",
+                "partitionKey",
+                rowKey);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- fix incorrect partition key position when building a test product

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840706ccfa8832480a4e427085aa8bd